### PR TITLE
Fix alsa_in build error

### DIFF
--- a/alsa_in.c
+++ b/alsa_in.c
@@ -15,7 +15,7 @@
 
 #include <jack/jack.h>
 #include <jack/jslist.h>
-#include <jack/memops.h>
+#include "memops.h"
 
 #include "alsa/asoundlib.h"
 


### PR DESCRIPTION
memops.h has been moved from the public jack headers residing in jack/
to include/.
