### PR TITLE
Set a dummy process callback so that timebase master is effective.

### DIFF
--- a/transport.c
+++ b/transport.c
@@ -118,6 +118,11 @@ void timebase(jack_transport_state_t state, jack_nframes_t nframes,
 	}
 }
 
+int jack_process(jack_nframes_t nframes, void *arg)
+{
+	return 0;
+}
+
 void jack_shutdown(void *arg)
 {
 #if defined(RL_READLINE_VERSION) && RL_READLINE_VERSION >= 0x0400
@@ -492,6 +497,7 @@ int main(int argc, char *argv[])
 	signal(SIGHUP, signal_handler);
 	signal(SIGINT, signal_handler);
 
+	jack_set_process_callback(client, jack_process, 0);
 	jack_on_shutdown(client, jack_shutdown, 0);
 
 	if (jack_activate(client)) {


### PR DESCRIPTION
Title says it all.

Without this simple patch, `jack_transport` won't ever function as a timebase master, no matter how many times one enters `master `[_cond_] or `tempo `_bpm_ under its command prompt.